### PR TITLE
#18 As a api user, I can upload a csv to create a report

### DIFF
--- a/lib/google_crawler_web/controllers/api/upload_controller.ex
+++ b/lib/google_crawler_web/controllers/api/upload_controller.ex
@@ -1,0 +1,20 @@
+defmodule GoogleCrawlerWeb.Api.UploadController do
+  use GoogleCrawlerWeb, :controller
+  alias GoogleCrawler.Search.Upload
+
+  def create(conn, %{"upload" => upload}) do
+    case Upload.process(conn.assigns[:current_user], upload["file"]) do
+      {:ok, _transaction_result} ->
+        conn
+        |> put_view(GoogleCrawlerWeb.Api.SuccessView)
+        |> put_status(201)
+        |> render("show.json", %{message: "File Processed successfully"})
+
+      _ ->
+        conn
+        |> put_view(GoogleCrawlerWeb.Api.ErrorView)
+        |> put_status(422)
+        |> render("show.json", %{message: "Some error occurred while processing the file"})
+    end
+  end
+end

--- a/lib/google_crawler_web/router.ex
+++ b/lib/google_crawler_web/router.ex
@@ -46,6 +46,12 @@ defmodule GoogleCrawlerWeb.Router do
     resources "/keywords", Api.KeywordController, only: [:show, :index]
   end
 
+  scope "/api", GoogleCrawlerWeb, as: :api do
+    pipe_through [:authenticate_user_by_token]
+
+    resources "/uploads", Api.UploadController, only: [:create]
+  end
+
   # Enables LiveDashboard only for development
   #
   # If you want to use the LiveDashboard in production, you should put

--- a/lib/google_crawler_web/views/api/success_view.ex
+++ b/lib/google_crawler_web/views/api/success_view.ex
@@ -1,0 +1,13 @@
+defmodule GoogleCrawlerWeb.Api.SuccessView do
+  use GoogleCrawlerWeb, :view
+
+  def render("show.json", %{message: message}) do
+    %{
+      meta: [
+        %{
+          detail: message
+        }
+      ]
+    }
+  end
+end

--- a/lib/google_crawler_web/views/api/success_view.ex
+++ b/lib/google_crawler_web/views/api/success_view.ex
@@ -3,11 +3,9 @@ defmodule GoogleCrawlerWeb.Api.SuccessView do
 
   def render("show.json", %{message: message}) do
     %{
-      meta: [
-        %{
-          detail: message
-        }
-      ]
+      meta: %{
+        detail: message
+      }
     }
   end
 end

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -11,7 +11,6 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
 
       result_conn =
         conn
-        |> log_in_user(user)
         |> put_req_header("x-token", Base.encode64(token.token))
         |> get(Routes.api_keyword_path(conn, :index))
 
@@ -48,7 +47,6 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
 
       result_conn =
         conn
-        |> log_in_user(user)
         |> put_req_header("x-token", Base.encode64(token.token))
         |> get(Routes.api_keyword_path(conn, :index), %{
           "filter" => %{"min_links_count" => 2, "max_links_count" => 4}
@@ -67,7 +65,6 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
 
       result_conn =
         conn
-        |> log_in_user(user)
         |> put_req_header("x-token", Base.encode64(token.token))
         |> get(Routes.api_keyword_path(conn, :index), %{"filter" => %{"term" => "lan"}})
 

--- a/test/google_crawler_web/controllers/api/upload_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/upload_controller_test.exs
@@ -4,7 +4,7 @@ defmodule GoogleCrawlerWeb.Api.UploadControllerTest do
   alias GoogleCrawler.Search.Keyword
 
   describe "POST create/2" do
-    test "creates the keywords when file is succesfully processed", %{conn: conn} do
+    test "creates the keywords when file is successfully processed", %{conn: conn} do
       user = insert(:user)
       token = insert(:user_token, user: user, context: "api")
       upload = %Plug.Upload{path: "test/support/fixtures/csv/valid.csv", filename: "upload.csv"}
@@ -16,7 +16,7 @@ defmodule GoogleCrawlerWeb.Api.UploadControllerTest do
       assert Repo.aggregate(Keyword, :count) == 2
     end
 
-    test "returns success message in meta when file is succesfully processed", %{conn: conn} do
+    test "returns success message in meta when file is successfully processed", %{conn: conn} do
       user = insert(:user)
       token = insert(:user_token, user: user, context: "api")
       upload = %Plug.Upload{path: "test/support/fixtures/csv/valid.csv", filename: "upload.csv"}
@@ -27,11 +27,11 @@ defmodule GoogleCrawlerWeb.Api.UploadControllerTest do
         |> post(Routes.api_upload_path(conn, :create), %{upload: %{file: upload}})
 
       assert json_response(result_conn, 201) == %{
-               "meta" => [%{"detail" => "File Processed successfully"}]
+               "meta" => %{"detail" => "File Processed successfully"}
              }
     end
 
-    test "does NOT create keywords when file is NOT succesfully processed", %{conn: conn} do
+    test "does NOT create keywords when file is NOT successfully processed", %{conn: conn} do
       user = insert(:user)
       token = insert(:user_token, user: user, context: "api")
 
@@ -47,7 +47,7 @@ defmodule GoogleCrawlerWeb.Api.UploadControllerTest do
       assert Repo.aggregate(Keyword, :count) == 0
     end
 
-    test "returns error message when file is NOT succesfully processed", %{conn: conn} do
+    test "returns error message when file is NOT successfully processed", %{conn: conn} do
       user = insert(:user)
       token = insert(:user_token, user: user, context: "api")
       upload = %Plug.Upload{path: "test/support/fixtures/csv/invalid.csv", filename: "upload.csv"}

--- a/test/google_crawler_web/controllers/api/upload_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/upload_controller_test.exs
@@ -1,0 +1,65 @@
+defmodule GoogleCrawlerWeb.Api.UploadControllerTest do
+  use GoogleCrawlerWeb.ConnCase, async: true
+  alias GoogleCrawler.Repo
+  alias GoogleCrawler.Search.Keyword
+
+  describe "POST create/2" do
+    test "creates the keywords when file is succesfully processed", %{conn: conn} do
+      user = insert(:user)
+      token = insert(:user_token, user: user, context: "api")
+      upload = %Plug.Upload{path: "test/support/fixtures/csv/valid.csv", filename: "upload.csv"}
+
+      conn
+      |> put_req_header("x-token", Base.encode64(token.token))
+      |> post(Routes.api_upload_path(conn, :create), %{upload: %{file: upload}})
+
+      assert Repo.aggregate(Keyword, :count) == 2
+    end
+
+    test "returns success message in meta when file is succesfully processed", %{conn: conn} do
+      user = insert(:user)
+      token = insert(:user_token, user: user, context: "api")
+      upload = %Plug.Upload{path: "test/support/fixtures/csv/valid.csv", filename: "upload.csv"}
+
+      result_conn =
+        conn
+        |> put_req_header("x-token", Base.encode64(token.token))
+        |> post(Routes.api_upload_path(conn, :create), %{upload: %{file: upload}})
+
+      assert json_response(result_conn, 201) == %{
+               "meta" => [%{"detail" => "File Processed successfully"}]
+             }
+    end
+
+    test "does NOT create keywords when file is NOT succesfully processed", %{conn: conn} do
+      user = insert(:user)
+      token = insert(:user_token, user: user, context: "api")
+
+      upload = %Plug.Upload{
+        path: "test/support/fixtures/csv/invalid.csv",
+        filename: "invalid_upload.csv"
+      }
+
+      conn
+      |> put_req_header("x-token", Base.encode64(token.token))
+      |> post(Routes.api_upload_path(conn, :create), %{upload: %{file: upload}})
+
+      assert Repo.aggregate(Keyword, :count) == 0
+    end
+
+    test "returns error message when file is NOT succesfully processed", %{conn: conn} do
+      user = insert(:user)
+      token = insert(:user_token, user: user, context: "api")
+      upload = %Plug.Upload{path: "test/support/fixtures/csv/invalid.csv", filename: "upload.csv"}
+
+      result_conn =
+        conn
+        |> put_req_header("x-token", Base.encode64(token.token))
+        |> post(Routes.api_upload_path(conn, :create), %{upload: %{file: upload}})
+
+      assert json_response(result_conn, 422) == %{
+               "errors" => [%{"detail" => "Some error occurred while processing the file"}]
+             }
+    end
+  end
+end

--- a/test/google_crawler_web/controllers/upload_controller_test.exs
+++ b/test/google_crawler_web/controllers/upload_controller_test.exs
@@ -17,7 +17,7 @@ defmodule GoogleCrawlerWeb.UploadControllerTest do
   end
 
   describe "POST create/2" do
-    test "creates the keywords when file is succesfully processed", %{conn: conn} do
+    test "creates the keywords when file is successfully processed", %{conn: conn} do
       upload = %Plug.Upload{path: "test/support/fixtures/csv/valid.csv", filename: "upload.csv"}
 
       post(conn, Routes.upload_path(conn, :create), %{upload: %{file: upload}})
@@ -25,7 +25,7 @@ defmodule GoogleCrawlerWeb.UploadControllerTest do
       assert Repo.aggregate(Keyword, :count) == 2
     end
 
-    test "sets flash message and redirects when file is succesfully processed", %{conn: conn} do
+    test "sets flash message and redirects when file is successfully processed", %{conn: conn} do
       upload = %Plug.Upload{path: "test/support/fixtures/csv/valid.csv", filename: "upload.csv"}
 
       result_conn = post(conn, Routes.upload_path(conn, :create), %{upload: %{file: upload}})
@@ -35,7 +35,7 @@ defmodule GoogleCrawlerWeb.UploadControllerTest do
       assert get_flash(result_conn, :info) == "File processed successfully"
     end
 
-    test "does NOT create keywords when file is NOT succesfully processed", %{conn: conn} do
+    test "does NOT create keywords when file is NOT successfully processed", %{conn: conn} do
       upload = %Plug.Upload{
         path: "test/support/fixtures/csv/invalid.csv",
         filename: "invalid_upload.csv"
@@ -46,7 +46,7 @@ defmodule GoogleCrawlerWeb.UploadControllerTest do
       assert Repo.aggregate(Keyword, :count) == 0
     end
 
-    test "sets flash message and redirects when file is NOT succesfully processed", %{conn: conn} do
+    test "sets flash message and redirects when file is NOT successfully processed", %{conn: conn} do
       upload = %Plug.Upload{path: "test/support/fixtures/csv/invalid.csv", filename: "upload.csv"}
 
       result_conn = post(conn, Routes.upload_path(conn, :create), %{upload: %{file: upload}})


### PR DESCRIPTION
## What happened

✅ Added api for uploading a file
 
## Insight

Needed to disable EnsureJsonApiSpec for upload csv route, as the content_type is `multipart/form-data` for uploading a file
 
## Proof Of Work

Postman Collection: https://identity.getpostman.com/handover/multifactor?user=6401217&handover_token=8935a034-d159-4252-bc86-93b0997f62d4

<img width="2557" alt="Screen Shot 2564-06-29 at 14 54 30" src="https://user-images.githubusercontent.com/11224179/123760285-e2908100-d8ea-11eb-9543-e6ebcb8473e5.png">
